### PR TITLE
pin revisions in default.xml

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -6,26 +6,26 @@
   <remote fetch="git://git.openembedded.org" name="oe"/>
   <remote fetch="http://git.shr-project.org" name="shr"/>
   <remote fetch="http://git.yoctoproject.org" name="yocto"/>
-  
+
   <default revision="gatesgarth" sync-j="4"/>
-  
-  <project name="96boards/meta-96boards" path="layers/meta-96boards" remote="github" revision="master"/>
-  <project name="96boards/meta-rpb" path="layers/meta-rpb" remote="github" revision="master"/>
+
+  <project name="96boards/meta-96boards" path="layers/meta-96boards" remote="github" revision="29fe2079656cf74f526a8cc990259495ed092c43"/>
+  <project name="96boards/meta-rpb" path="layers/meta-rpb" remote="github" revision="964531bfbcb3cdd111c09935d7b713edffcb1dcd"/>
   <project name="roystonvasey/oe-rpb-manifest" path="conf" remote="github" revision="qcom/gatesgarth">
     <linkfile dest="setup-environment" src="setup-environment-internal"/>
   </project>
-  <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github" revision="master"/>
-  <project name="git/meta-arm" path="layers/meta-arm" remote="yocto" revision="master"/>
+  <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github" revision="1205a4e517f3800dcbd82d007125eaf003ea225b"/>
+  <project name="git/meta-arm" path="layers/meta-arm" remote="yocto" revision="75c9cc3bf8e401530865f22c89eef33ffc852ef9"/>
   <project name="git/meta-selinux" path="layers/meta-selinux" remote="yocto"/>
-  <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto" revision="master"/>
-  <project name="kraj/meta-clang" path="layers/meta-clang" remote="github" revision="master"/>
+  <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto" revision="gatesgarth"/>
+  <project name="kraj/meta-clang" path="layers/meta-clang" remote="github" revision="gatesgarth"/>
   <project name="meta-python2" path="layers/meta-python2" remote="oe"/>
   <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>
-  <project name="meta-rust/meta-rust" path="layers/meta-rust" remote="github" revision="master"/>
-  <project name="ndechesne/meta-qcom" path="layers/meta-qcom" remote="github"  revision="master"/>
+  <project name="meta-rust/meta-rust" path="layers/meta-rust" remote="github" revision="c72b2dda3a4f70ed257c7de9bedb4b04732970a4"/>
+  <project name="ndechesne/meta-qcom" path="layers/meta-qcom" remote="github"  revision="c0138eb41dcd06f2197bbde6146a33d9a3c1af70"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github" revision="1.48"/>
-  <project name="openembedded/meta-backports" path="layers/meta-backports" remote="linaro" revision="master"/>
-  <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="master"/>
+  <project name="openembedded/meta-backports" path="layers/meta-backports" remote="linaro" revision="bcf91bc2850790aec41e6dc10aa58b6e8fc4617c"/>
+  <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="11091b487e1ad4c6a4adfac34d958a3d9d9ccd17"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
   <!--<project name="Connexionz/meta-connexionz" path="layers/meta-connexionz" remote="github" revision="docker-build"/>-->


### PR DESCRIPTION
pin to specific revisions in default.xml for all important repos so that we can get a consistently build-able environment.